### PR TITLE
feat: Add opcache blacklist support for staging PHP environment

### DIFF
--- a/example/laravel/docker/staging/php/Dockerfile
+++ b/example/laravel/docker/staging/php/Dockerfile
@@ -11,6 +11,8 @@ COPY . /var/www/app
 
 COPY ./docker/staging/php/local.ini /usr/local/etc/php/conf.d/local.ini
 
+COPY ./docker/staging/php/opcache.blacklist /usr/local/etc/php/opcache.blacklist
+
 RUN mkdir /.config/ && chmod -R 777 /.config
 
 RUN chmod -R 777 bootstrap

--- a/example/laravel/docker/staging/php/local.ini
+++ b/example/laravel/docker/staging/php/local.ini
@@ -24,6 +24,7 @@ opcache.save_comments = 1
 opcache.fast_shutdown = 1
 opcache.jit = 1255
 opcache.jit_buffer_size = 100M
+opcache.blacklist_filename=/usr/local/etc/php/opcache.blacklist
 
 ; Session settings
 session.gc_maxlifetime = 7200

--- a/example/laravel/docker/staging/supervisor/Dockerfile
+++ b/example/laravel/docker/staging/supervisor/Dockerfile
@@ -17,6 +17,8 @@ COPY ./docker/staging/supervisor/supervisord.conf /etc/supervisord.conf
 
 COPY ./docker/staging/php/local.ini /usr/local/etc/php/conf.d/local.ini
 
+COPY ./docker/staging/php/opcache.blacklist /usr/local/etc/php/opcache.blacklist
+
 COPY ./docker/staging/supervisor/conf.d /etc/supervisor/conf.d
 
 COPY ./docker/staging/supervisor/entrypoint.sh ./entrypoint.sh


### PR DESCRIPTION
### Summary

This PR adds support for specifying an `opcache.blacklist` file in the Docker container. This allows developers to exclude files or directories from being cached by PHP's OPCache.

### Changes Made

- `example/laravel/docker/staging/php/opcache.blacklist`:  
  New file listing paths to exclude from OPCache.

- `example/laravel/docker/staging/php/local.ini`:  
  Added `opcache.blacklist_filename` directive to load blacklist file.

- `example/laravel/docker/staging/php/Dockerfile`:  
  Updated to copy `opcache.blacklist` into the container.

- `example/laravel/docker/staging/supervisor/Dockerfile`:  
  Adjusted if needed to propagate the blacklist or reload PHP correctly.

### Why This is Useful

- Improves development workflows where some scripts or tools should be ignored by OPCache.
- Keeps caching flexible and project-specific.

### Checklist

- [x] My changes build correctly and do not break existing functionality.
- [x] I have tested this change locally.
- [x] I followed the style of the existing project.

### Related Issues

N/A — this is a feature addition.
